### PR TITLE
revert norms schema to v6

### DIFF
--- a/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
@@ -14,7 +14,7 @@ keyword_default = { "type": "keyword", "index": true }.to_json
 full_text_with_raw_copy = {
   "type": "text",
   "index": true,
-  "norms": false,
+  "norms": { "enabled": false },
   "fields": {
     "raw": {
       "type": "keyword",


### PR DESCRIPTION
## Changes Proposed

revert the schema of the norms key to match v6.

## Security Considerations

none
