### PR TITLE
Use cg blobstore and update blobs

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,11 +1,11 @@
 cf-kibana/kibana-7.6.1-linux-x86_64.tar.gz:
   size: 249498863
-  object_id: b334c4f1-5add-4d24-76fa-bdf400415d56
+  object_id: 3a8a77b1-b3ec-4aa5-76c0-aac7b5fde0ca
   sha: sha256:da636529511e707bbbc621dc131ff2ed18f50fe0df30821c375d16c5ba4248f6
 redis/redis-3.2.9.tar.gz:
   size: 1547695
-  object_id: a1230536-4203-40b9-97e1-9f11d470308d
-  sha: 8fad759f28bcb14b94254124d824f1f3ed7b6aa6
+  object_id: d0b8b484-f735-428c-4bb7-5129d1ef45aa
+  sha: sha256:6eaacfa983b287e440d0839ead20c2231749d5d6b78bbe0e0ffa3a890c59ff26
 requests/certifi-2019.11.28-py2.py3-none-any.whl:
   size: 156030
   object_id: 26a907f0-c975-478e-46f2-fd178e510f3d
@@ -28,5 +28,5 @@ requests/urllib3-1.25.8-py2.py3-none-any.whl:
   sha: sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc
 ruby/rake-12.3.2.gem:
   size: 87040
-  object_id: eb36ff1c-24a2-4291-605c-96f37985481f
+  object_id: db165d94-7485-4db2-5fd3-305f9202f70c
   sha: sha256:56362f144a29ffbc5e49161a80ca4e2e6b7da2946170067d624d7603ed51c5eb

--- a/config/final.yml
+++ b/config/final.yml
@@ -2,5 +2,6 @@
 blobstore:
   provider: s3
   options:
-    bucket_name: logsearch-for-cloudfoundry
+    region: us-gov-west-1
+    bucket_name: cloud-gov-release-blobstore
 final_name: logsearch-for-cloudfoundry


### PR DESCRIPTION
## Changes Proposed

- Uses the cloud.gov blobstore instead of the default.
- Updates blobs to v211.1.0 in our blobstore

## Security Considerations

none
