### PR TITLE
Update Elasticsearch template templates

### DIFF
--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
@@ -10,7 +10,7 @@ keyword_default = { "type": "keyword", "index": true }.to_json
 
 %>
 {
-  "index_templates" : ["<%= p('elasticsearch_config.app_index_prefix') %>*"],
+  "index_patterns" : ["<%= p('elasticsearch_config.app_index_prefix') %>*"],
   "priority": 203,
   "template": {
     "settings": <%= p('elasticsearch_config.app_index_settings', {}).to_json %>,

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
@@ -10,139 +10,141 @@ keyword_default = { "type": "keyword", "index": true }.to_json
 
 %>
 {
-  "template" : "<%= p('elasticsearch_config.app_index_prefix') %>*",
-  "settings": <%= p('elasticsearch_config.app_index_settings', {}).to_json %>,
-  "order": 203,
-  "mappings" : {
-    <%# ------------ App specific fields %>
-    "properties": {
-      "@cf": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "app":          <%= keyword_default %>,
-          "app_id":       <%= keyword_default %>,
-          "app_instance": { "type": "long" },
-          "org":          <%= keyword_default %>,
-          "org_id":       <%= keyword_default %>,
-          "space":        <%= keyword_default %>,
-          "space_id":     <%= keyword_default %>
-        }
-      },
-      "logmessage": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "message_type":   <%= keyword_default %>
-        }
-      },
-      "rtr": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "response_time_ms":       { "type": "long" },
-          "remote_addr":            <%= keyword_default %>,
-          "x_forwarded_proto":      <%= keyword_default %>,
-          "x_forwarded_for":        <%= keyword_default %>,
-          "vcap_request_id":        <%= keyword_default %>,
-          "body_bytes_sent":        { "type": "long" },
-          "hostname":               <%= keyword_default %>,
-          "timestamp":              <%= keyword_default %>,
-          "request_bytes_received": { "type": "long" },
-          "verb":                   <%= keyword_default %>,
-          "path":                   <%= keyword_default %>,
-          "http_spec":              <%= keyword_default %>,
-          "referer":                <%= keyword_default %>,
-          "http_user_agent":        <%= keyword_default %>,
-          "status":                 { "type": "long" },
-          "src": {
-            "type": "object",
-            "dynamic": true,
-            "properties": {
-              "host": <%= keyword_default %>,
-              "port": { "type": "long" }
-            }
-          },
-          "dst": {
-            "type": "object",
-            "dynamic": true,
-            "properties": {
-              "host": <%= keyword_default %>,
-              "port": { "type": "long" }
-            }
-          },
-          "app": {
-            "type": "object",
-            "dynamic": true,
-            "properties": {
-              "id": <%= keyword_default %>,
-              "index": { "type": "long" }
+  "index_templates" : ["<%= p('elasticsearch_config.app_index_prefix') %>*"],
+  "priority": 203,
+  "template": {
+    "settings": <%= p('elasticsearch_config.app_index_settings', {}).to_json %>,
+    "mappings" : {
+      <%# ------------ App specific fields %>
+      "properties": {
+        "@cf": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "app":          <%= keyword_default %>,
+            "app_id":       <%= keyword_default %>,
+            "app_instance": { "type": "long" },
+            "org":          <%= keyword_default %>,
+            "org_id":       <%= keyword_default %>,
+            "space":        <%= keyword_default %>,
+            "space_id":     <%= keyword_default %>
+          }
+        },
+        "logmessage": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "message_type":   <%= keyword_default %>
+          }
+        },
+        "rtr": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "response_time_ms":       { "type": "long" },
+            "remote_addr":            <%= keyword_default %>,
+            "x_forwarded_proto":      <%= keyword_default %>,
+            "x_forwarded_for":        <%= keyword_default %>,
+            "vcap_request_id":        <%= keyword_default %>,
+            "body_bytes_sent":        { "type": "long" },
+            "hostname":               <%= keyword_default %>,
+            "timestamp":              <%= keyword_default %>,
+            "request_bytes_received": { "type": "long" },
+            "verb":                   <%= keyword_default %>,
+            "path":                   <%= keyword_default %>,
+            "http_spec":              <%= keyword_default %>,
+            "referer":                <%= keyword_default %>,
+            "http_user_agent":        <%= keyword_default %>,
+            "status":                 { "type": "long" },
+            "src": {
+              "type": "object",
+              "dynamic": true,
+              "properties": {
+                "host": <%= keyword_default %>,
+                "port": { "type": "long" }
+              }
+            },
+            "dst": {
+              "type": "object",
+              "dynamic": true,
+              "properties": {
+                "host": <%= keyword_default %>,
+                "port": { "type": "long" }
+              }
+            },
+            "app": {
+              "type": "object",
+              "dynamic": true,
+              "properties": {
+                "id": <%= keyword_default %>,
+                "index": { "type": "long" }
+              }
             }
           }
-        }
-      },
-      "geoip"  : {
-        "type" : "object",
-        "dynamic": true,
-        "properties": {
-          "location": { "type": "geo_point" },
-          "timezone": <%= keyword_default %>
-        }
-      },
-      "containermetric": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "memory_bytes_quota": { "type": "long" },
-          "memory_bytes":       { "type": "long" },
-          "disk_bytes_quota":   { "type": "long" },
-          "disk_bytes":         { "type": "long" },
-          "cpu_percentage":     { "type": "scaled_float", "scaling_factor": 100 }
-        }
-      },
-      "valuemetric": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "unit":  <%= keyword_default %>,
-          "name":  <%= keyword_default %>,
-          "value": { "type": "long" }
-        }
-      },
-      "counterevent": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "delta":  { "type": "long" },
-          "name":  <%= keyword_default %>,
-          "total": { "type": "long" }
-        }
-      },
-      "error": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "source":  <%= keyword_default %>,
-          "code": { "type": "long" }
-        }
-      },      
-      "httpstartstop": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "stop_timestamp": { "type": "long" },
-          "request_id":     <%= keyword_default %>,
-          "peer_type":      <%= keyword_default %>,
-          "method":         <%= keyword_default %>,
-          "uri":            <%= keyword_default %>,
-          "remote_addr":    <%= keyword_default %>,
-          "user_agent":     <%= keyword_default %>,
-          "status_code":    { "type": "long" },
-          "content_length": { "type": "long" },
-          "instance_index": { "type": "long" },
-          "instance_id":    <%= keyword_default %>,
-          "forwarded":      <%= keyword_default %>,
-          "duration_ms":    { "type": "long" }
+        },
+        "geoip"  : {
+          "type" : "object",
+          "dynamic": true,
+          "properties": {
+            "location": { "type": "geo_point" },
+            "timezone": <%= keyword_default %>
+          }
+        },
+        "containermetric": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "memory_bytes_quota": { "type": "long" },
+            "memory_bytes":       { "type": "long" },
+            "disk_bytes_quota":   { "type": "long" },
+            "disk_bytes":         { "type": "long" },
+            "cpu_percentage":     { "type": "scaled_float", "scaling_factor": 100 }
+          }
+        },
+        "valuemetric": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "unit":  <%= keyword_default %>,
+            "name":  <%= keyword_default %>,
+            "value": { "type": "long" }
+          }
+        },
+        "counterevent": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "delta":  { "type": "long" },
+            "name":  <%= keyword_default %>,
+            "total": { "type": "long" }
+          }
+        },
+        "error": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "source":  <%= keyword_default %>,
+            "code": { "type": "long" }
+          }
+        },
+        "httpstartstop": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "stop_timestamp": { "type": "long" },
+            "request_id":     <%= keyword_default %>,
+            "peer_type":      <%= keyword_default %>,
+            "method":         <%= keyword_default %>,
+            "uri":            <%= keyword_default %>,
+            "remote_addr":    <%= keyword_default %>,
+            "user_agent":     <%= keyword_default %>,
+            "status_code":    { "type": "long" },
+            "content_length": { "type": "long" },
+            "instance_index": { "type": "long" },
+            "instance_id":    <%= keyword_default %>,
+            "forwarded":      <%= keyword_default %>,
+            "duration_ms":    { "type": "long" }
+          }
         }
       }
     }

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
@@ -11,7 +11,7 @@ keyword_default = { "type": "keyword", "index": true }.to_json
 
 %>
 {
-  "index_templates" : ["<%= p('elasticsearch_config.platform_index_prefix') %>*"],
+  "index_patterns" : ["<%= p('elasticsearch_config.platform_index_prefix') %>*"],
   "priority": 204,
   "template": {
     "settings": <%= p('elasticsearch_config.platform_index_settings', {}).to_json %>,

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
@@ -11,73 +11,75 @@ keyword_default = { "type": "keyword", "index": true }.to_json
 
 %>
 {
-  "template" : "<%= p('elasticsearch_config.platform_index_prefix') %>*",
-  "settings": <%= p('elasticsearch_config.platform_index_settings', {}).to_json %>,
-  "order": 204,
-  "mappings" : {
-    <%# ------------ Platform specific fields %>
-    "properties": {
-      "geoip"  : {
-        "type" : "object",
-        "dynamic": true,
-        "properties" : {
-          "location" : { "type" : "geo_point" }
-        }
-      },
-      "uaa": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "timestamp":    <%= keyword_default %>,
-          "pid":          { "type": "long" },
-          "thread":       <%= keyword_default %>,
-          "log_category": <%= keyword_default %>,
-          "audit": {
-            "type": "object",
-            "dynamic": true,
-            "properties": {
-              "type":             <%= keyword_default %>,
-              "data":             <%= keyword_default %>,
-              "principal":        <%= keyword_default %>,
-              "origin":           <%= keyword_default %>,
-              "identity_zone_id": <%= keyword_default %>,
-              "remote_address":   <%= keyword_default %>
+  "index_templates" : ["<%= p('elasticsearch_config.platform_index_prefix') %>*"],
+  "priority": 204,
+  "template": {
+    "settings": <%= p('elasticsearch_config.platform_index_settings', {}).to_json %>,
+    "mappings" : {
+      <%# ------------ Platform specific fields %>
+      "properties": {
+        "geoip"  : {
+          "type" : "object",
+          "dynamic": true,
+          "properties" : {
+            "location" : { "type" : "geo_point" }
+          }
+        },
+        "uaa": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "timestamp":    <%= keyword_default %>,
+            "pid":          { "type": "long" },
+            "thread":       <%= keyword_default %>,
+            "log_category": <%= keyword_default %>,
+            "audit": {
+              "type": "object",
+              "dynamic": true,
+              "properties": {
+                "type":             <%= keyword_default %>,
+                "data":             <%= keyword_default %>,
+                "principal":        <%= keyword_default %>,
+                "origin":           <%= keyword_default %>,
+                "identity_zone_id": <%= keyword_default %>,
+                "remote_address":   <%= keyword_default %>
+              }
             }
           }
-        }
-      },
-      "haproxy": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "client_ip":                  <%= keyword_default %>,
-          "client_port":                { "type": "long" },
-          "accept_date":                <%= keyword_default %>,
-          "frontend_name":              <%= keyword_default %>,
-          "backend_name":               <%= keyword_default %>,
-          "bind_name":                  <%= keyword_default %>,
-          "server_name":                <%= keyword_default %>,
-          "time_request":               { "type": "long" },
-          "time_queue":                 { "type": "long" },
-          "time_backend_connect":       { "type": "long" },
-          "time_backend_response":      { "type": "long" },
-          "time_duration":              { "type": "long" },
-          "http_status_code":           { "type": "long" },
-          "bytes_read":                 { "type": "long" },
-          "captured_request_cookie":    <%= keyword_default %>,
-          "captured_response_cookie":   <%= keyword_default %>,
-          "termination_state":          <%= keyword_default %>,
-          "actconn":                    { "type": "long" },
-          "feconn":                     { "type": "long" },
-          "beconn":                     { "type": "long" },
-          "srvconn":                    { "type": "long" },
-          "retries":                    { "type": "long" },
-          "srv_queue":                  { "type": "long" },
-          "backend_queue":              { "type": "long" },
-          "captured_request_headers":   <%= keyword_default %>,
-          "captured_response_headers":  <%= keyword_default %>,
-          "http_request":               <%= keyword_default %>,
-          "http_request_verb":          <%= keyword_default %>
+        },
+        "haproxy": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "client_ip":                  <%= keyword_default %>,
+            "client_port":                { "type": "long" },
+            "accept_date":                <%= keyword_default %>,
+            "frontend_name":              <%= keyword_default %>,
+            "backend_name":               <%= keyword_default %>,
+            "bind_name":                  <%= keyword_default %>,
+            "server_name":                <%= keyword_default %>,
+            "time_request":               { "type": "long" },
+            "time_queue":                 { "type": "long" },
+            "time_backend_connect":       { "type": "long" },
+            "time_backend_response":      { "type": "long" },
+            "time_duration":              { "type": "long" },
+            "http_status_code":           { "type": "long" },
+            "bytes_read":                 { "type": "long" },
+            "captured_request_cookie":    <%= keyword_default %>,
+            "captured_response_cookie":   <%= keyword_default %>,
+            "termination_state":          <%= keyword_default %>,
+            "actconn":                    { "type": "long" },
+            "feconn":                     { "type": "long" },
+            "beconn":                     { "type": "long" },
+            "srvconn":                    { "type": "long" },
+            "retries":                    { "type": "long" },
+            "srv_queue":                  { "type": "long" },
+            "backend_queue":              { "type": "long" },
+            "captured_request_headers":   <%= keyword_default %>,
+            "captured_response_headers":  <%= keyword_default %>,
+            "http_request":               <%= keyword_default %>,
+            "http_request_verb":          <%= keyword_default %>
+          }
         }
       }
     }

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
@@ -27,39 +27,41 @@ full_text_with_raw_copy = {
 
 %>
 {
-  "template" : "<%= p('elasticsearch_config.index_prefix') %>*",
-  "settings": <%= p('elasticsearch_config.index_settings', {}).to_json %>,
-  "order": 202,
-  "mappings" : {
-    "properties" : {
-      <%# ------  common fields %>
-      "tags":        <%= keyword_default %>,
-      "@input":      <%= keyword_default %>,
-      "@index_type": <%= keyword_default %>,
-      "@type":       <%= keyword_default %>,
-      "@timestamp":  { "type": "date" },
-      "@message":    <%= full_text_with_raw_copy %>,
-      "@level":      <%= keyword_default %>,
-      "@shipper": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "name":     <%= keyword_default %>,
-          "priority": { "type": "long" }
-        }
-      },
-      "@source": {
-        "type": "object",
-        "dynamic": true,
-        "properties": {
-          "deployment": <%= keyword_default %>,
-          "host":       <%= keyword_default %>,
-          "job":        <%= keyword_default %>,
-          "job_index":  <%= keyword_default %>,
-          "index":      { "type": "long" },
-          "component":  <%= keyword_default %>,
-          "type":       <%= keyword_default %>,
-          "vm":         <%= keyword_default %>
+  "index_templates" : ["<%= p('elasticsearch_config.index_prefix') %>*"],
+  "priority": 202,
+  "template": {
+    "settings": <%= p('elasticsearch_config.index_settings', {}).to_json %>,
+    "mappings" : {
+      "properties" : {
+        <%# ------  common fields %>
+        "tags":        <%= keyword_default %>,
+        "@input":      <%= keyword_default %>,
+        "@index_type": <%= keyword_default %>,
+        "@type":       <%= keyword_default %>,
+        "@timestamp":  { "type": "date" },
+        "@message":    <%= full_text_with_raw_copy %>,
+        "@level":      <%= keyword_default %>,
+        "@shipper": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "name":     <%= keyword_default %>,
+            "priority": { "type": "long" }
+          }
+        },
+        "@source": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "deployment": <%= keyword_default %>,
+            "host":       <%= keyword_default %>,
+            "job":        <%= keyword_default %>,
+            "job_index":  <%= keyword_default %>,
+            "index":      { "type": "long" },
+            "component":  <%= keyword_default %>,
+            "type":       <%= keyword_default %>,
+            "vm":         <%= keyword_default %>
+          }
         }
       }
     }

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
@@ -27,7 +27,7 @@ full_text_with_raw_copy = {
 
 %>
 {
-  "index_templates" : ["<%= p('elasticsearch_config.index_prefix') %>*"],
+  "index_patterns" : ["<%= p('elasticsearch_config.index_prefix') %>*"],
   "priority": 202,
   "template": {
     "settings": <%= p('elasticsearch_config.index_settings', {}).to_json %>,


### PR DESCRIPTION
This changeset updates the format of the Elasticsearch templates to account for breaking changes that were introduced in version 7.8 and 7.9 of Elasticsearch.

## Changes Proposed
- Update JSON structure

## Security Considerations
- None:  JSON changes
