### PR TITLE
Add filtering for auto-suggest values

### DIFF
--- a/src/kibana-cf_authentication/server/index.js
+++ b/src/kibana-cf_authentication/server/index.js
@@ -158,12 +158,15 @@ module.exports = (kibana) => {
         // add routes to server
         server.route(initRoutes(server, config, cache))
 
-        // Redirect _msearch and _search through our own route so we can modify the payload
+        // Redirect _msearch and _search through our own routes so that we can modify the payload
+        // This also includes the auto-suggestions for filters.
         server.ext('onRequest', (request, reply) => {
           if (/elasticsearch\/_msearch/.test(request.path) && !request.auth.artifacts) {
             request.setUrl('/_filtered_msearch')
           } else if (/internal\/search\/es/.test(request.path) && !request.auth.artifacts) {
             request.setUrl('/_filtered_internal_search')
+          } else if (/api\/kibana\/suggestions\/values/.test(request.path) && !request.auth.artifacts) {
+            request.setUrl('_filtered_suggestions')
           } else {
             const match = /elasticsearch\/([^\/]+)\/_search/.exec(request.path)
 

--- a/src/kibana-cf_authentication/server/routes.js
+++ b/src/kibana-cf_authentication/server/routes.js
@@ -190,7 +190,64 @@ module.exports = (server, config, cache) => {
         handler: async (request, h) => {
           const options = {
             method: 'POST',
-            url: "/internal/search/es",
+            url: '/internal/search/es',
+            artifacts: true
+          }
+
+          let cached
+          try {
+            cached = await cache.get(request.auth.credentials.session_id)
+
+            if (cached
+              && cached.account
+              && cached.account.orgs
+              && cached.account.orgs.indexOf(config.get('authentication.cf_system_org')) === -1
+              && !(config.get('authentication.skip_authorization'))) {
+              let payload = JSON.parse(request.payload.toString() || '{}')
+              payload = filterInternalQuery(payload, cached)
+
+              options.payload = new Buffer(JSON.stringify(payload))
+            } else {
+              options.payload = request.payload
+            }
+          } catch (error) {
+            server.log(['error', 'authentication', 'session:get:_filtered_internal_search'], JSON.stringify(error))
+          } finally {
+            options.headers = request.headers
+
+            delete options.headers.host
+            delete options.headers['user-agent']
+            delete options.headers['accept-encoding']
+
+            options.headers['content-length'] = (options.payload && options.payload.length)
+              ? options.payload.length
+              : 0
+
+            const resp = await server.inject(options)
+
+            const response = h.response()
+
+            response.code(resp.statusCode)
+            response.type(resp.headers['content-type'])
+            response.passThrough(true)
+
+            return resp.result || resp.payload
+          }
+        }
+      }
+    },
+    {
+      method: 'POST',
+      path: '/_filtered_suggestions',
+      config: {
+        payload: {
+          parse: false
+        },
+        validate: { payload: null },
+        handler: async (request, h) => {
+          const options = {
+            method: 'POST',
+            url: '/api/kibana/suggestions/values/' + request.params.index,
             artifacts: true
           }
 


### PR DESCRIPTION
This changeset adds support for filering auto-suggest values based on the access and permissions granted to the authenticated user.

## Changes proposed
- Adds a new method to handle filtering suggestions
- Formatting updates

## Security considerations
- Prevents users from seeing suggestions for apps, orgs, spaces, etc., that they do not have access to when adding filters