### PR TITLE
Fix URL path check

### DIFF
--- a/src/kibana-cf_authentication/server/index.js
+++ b/src/kibana-cf_authentication/server/index.js
@@ -166,7 +166,7 @@ module.exports = (kibana) => {
           } else if (/internal\/search\/es/.test(request.path) && !request.auth.artifacts) {
             request.setUrl('/_filtered_internal_search')
           } else if (/api\/kibana\/suggestions\/values/.test(request.path) && !request.auth.artifacts) {
-            request.setUrl('_filtered_suggestions')
+            request.setUrl('/_filtered_suggestions')
           } else {
             const match = /elasticsearch\/([^\/]+)\/_search/.exec(request.path)
 


### PR DESCRIPTION
This changeset fixes a URL path that was missing a character.

## Changes proposed
- Adds a missing `/`

## Security considerations
- None; URL path change