### PR TITLE
Fix the request handling for filtered suggestions

### DIFF
--- a/src/kibana-cf_authentication/server/index.js
+++ b/src/kibana-cf_authentication/server/index.js
@@ -166,7 +166,8 @@ module.exports = (kibana) => {
           } else if (/internal\/search\/es/.test(request.path) && !request.auth.artifacts) {
             request.setUrl('/_filtered_internal_search')
           } else if (/api\/kibana\/suggestions\/values/.test(request.path) && !request.auth.artifacts) {
-            request.setUrl('/_filtered_suggestions')
+            const match = /api\/kibana\/suggestions\/values\/([^\/]+)/.exec(request.path)
+            request.setUrl('/' + match[1] + '/_filtered_suggestions')
           } else {
             const match = /elasticsearch\/([^\/]+)\/_search/.exec(request.path)
 

--- a/src/kibana-cf_authentication/server/routes.js
+++ b/src/kibana-cf_authentication/server/routes.js
@@ -238,7 +238,7 @@ module.exports = (server, config, cache) => {
     },
     {
       method: 'POST',
-      path: '/_filtered_suggestions',
+      path: '/{index}/_filtered_suggestions',
       config: {
         payload: {
           parse: false


### PR DESCRIPTION
This changeset fixes the request handling for filtered suggestions so that the index name flows through to the handler.

## Changes proposed
- Adds regex matching to retrieve the index name being searched

## Security considerations
- None; URL path handling fix