### PR TITLE
Swap filter function for payload modification

### DIFF
--- a/src/kibana-cf_authentication/server/routes.js
+++ b/src/kibana-cf_authentication/server/routes.js
@@ -263,7 +263,7 @@ module.exports = (server, config, cache) => {
               && cached.account.orgs.indexOf(config.get('authentication.cf_system_org')) === -1
               && !(config.get('authentication.skip_authorization'))) {
               let payload = JSON.parse(request.payload.toString() || '{}')
-              payload = filterInternalQuery(payload, cached)
+              payload = filterQuery(payload, cached)
 
               options.payload = new Buffer(JSON.stringify(payload))
             } else {


### PR DESCRIPTION
This changeset swaps the suggestion endpoint to use the `filterQuery` method instead of `filterInternalQuery`.

## Changes proposed
- Swap method calls

## Security Considerations
- None; switching function calls between two methods that are both already used.
