### PR TITLE
Adjust suggestion payload for edit filters

### DIFF
--- a/src/kibana-cf_authentication/server/helpers.js
+++ b/src/kibana-cf_authentication/server/helpers.js
@@ -14,6 +14,22 @@ const ensureKeys = (value, keys) => {
   return value
 }
 
+const filterSuggestionQuery = (payload, cached) => {
+  // query for /api/kibana/suggestions/values/<index name> endpoints after kibana 7.7
+  let boolFilter = ensureKeys(payload, ['boolFilter'])
+
+  boolFilter.must = boolFilter.must || []
+  // Note: the `must` clause may be an array or an object
+  if (isObject(boolFilter.must)) {
+    boolFilter.must = [boolFilter.must]
+  }
+  boolFilter.must.push(
+    { 'terms': { '@cf.space_id': cached.account.spaceIds } },
+    { 'terms': { '@cf.org_id': cached.account.orgIds } }
+  )
+  return payload
+}
+
 const filterInternalQuery = (payload, cached) => {
   // query for /internal/search/es endpoints after kibana 7.7
   let bool = ensureKeys(payload, ['params', 'body', 'query', 'bool'])

--- a/src/kibana-cf_authentication/server/routes.js
+++ b/src/kibana-cf_authentication/server/routes.js
@@ -263,7 +263,7 @@ module.exports = (server, config, cache) => {
               && cached.account.orgs.indexOf(config.get('authentication.cf_system_org')) === -1
               && !(config.get('authentication.skip_authorization'))) {
               let payload = JSON.parse(request.payload.toString() || '{}')
-              payload = filterQuery(payload, cached)
+              payload = filterSuggestionQuery(payload, cached)
 
               options.payload = new Buffer(JSON.stringify(payload))
             } else {


### PR DESCRIPTION
This changeset creates a new method to inject the org and space filtering into the payload used by the suggestion endpoint for the edit filter functionality in Kibana.

## Changes Proposed
- Adds a new method to modify the suggestion endpoint payload
- Changes the suggestion route handler to use the new method

## Security Considerations
- None; adjusting how the payload is constructed for filtering and modifying the route handler for suggestions