### PR TITLE
Correct return type

### DIFF
--- a/src/kibana-cf_authentication/server/index.js
+++ b/src/kibana-cf_authentication/server/index.js
@@ -166,9 +166,8 @@ module.exports = (kibana) => {
           } else if (/internal\/search\/es/.test(request.path) && !request.auth.artifacts) {
             request.setUrl('/_filtered_internal_search')
           } else if (/api\/kibana\/suggestions\/values/.test(request.path) && !request.auth.artifacts) {
-            //const match = /api\/kibana\/suggestions\/values\/([^\/]+)/.exec(request.path)
-            //request.setUrl('/' + match[1] + '/_filtered_suggestions')
-            request.setUrl('/_filtered_suggestions')
+            const match = /api\/kibana\/suggestions\/values\/([^\/]+)/.exec(request.path)
+            request.setUrl('/' + match[1] + '/_filtered_suggestions')
           } else {
             const match = /elasticsearch\/([^\/]+)\/_search/.exec(request.path)
 

--- a/src/kibana-cf_authentication/server/routes.js
+++ b/src/kibana-cf_authentication/server/routes.js
@@ -257,18 +257,9 @@ module.exports = (server, config, cache) => {
             cached = await cache.get(request.auth.credentials.session_id)
 
             if (cached.account.orgs.indexOf(config.get('authentication.cf_system_org')) === -1 && !(config.get('authentication.skip_authorization'))) {
-              const modifiedPayload = [];
-              const lines = request.payload.toString().split('\n')
-              const numLines = lines.length;
-              for (var i = 0; i < numLines - 1; i += 2) {
-                const indexes = lines[i]
-                let query = JSON.parse(lines[i + 1])
-
-                query = filterSuggestionQuery(query, cached)
-                modifiedPayload.push(indexes)
-                modifiedPayload.push(JSON.stringify(query))
-              }
-              options.payload = new Buffer(modifiedPayload.join('\n') + '\n')
+              let payload = JSON.parse(request.payload.toString() || '{}')
+              payload = filterSuggestionQuery(payload, cached)
+              options.payload = new Buffer(JSON.stringify(payload))
             } else {
               options.payload = request.payload
             }
@@ -287,12 +278,10 @@ module.exports = (server, config, cache) => {
             const response = h.response()
 
             if (resp.statusCode > 399) {
+              server.log(['error', 'authentication', 'session:get:_filtered_suggestions'], resp.result)
               response.code(200)
               response.type("application/json")
-              return response.ok({
-                body: JSON.stringify([])
-              }
-              )
+              return JSON.stringify([])
             }
 
             response.code(resp.statusCode)

--- a/src/kibana-cf_authentication/server/routes.js
+++ b/src/kibana-cf_authentication/server/routes.js
@@ -238,8 +238,7 @@ module.exports = (server, config, cache) => {
     },
     {
       method: 'POST',
-      //path: '/{index}/_filtered_suggestions',
-      path: '/_filtered_suggestions',
+      path: '/{index}/_filtered_suggestions',
       config: {
         payload: {
           parse: false
@@ -248,8 +247,7 @@ module.exports = (server, config, cache) => {
         handler: async (request, h) => {
           const options = {
             method: 'POST',
-            //url: '/api/kibana/suggestions/values/' + request.params.index,
-            url: '/api/kibana/suggestions/values/logs-app*',
+            url: '/api/kibana/suggestions/values/' + request.params.index,
             artifacts: true
           };
           let cached


### PR DESCRIPTION
## Changes Proposed

- fix payload manipulation for suggestion endpoint filtering. The original function was based on the _msearch filtering, which has a weird, non-JSON request body like:
  ```
  logs-app-2020.12.28
  {"json":{"for":["a", "query"]}}
  logs-app-2020.12.27
  {"json":{"for":["another", "query"]}}
  ```
  This function now more closely matches the other filtered endpoint functions
- run suggestions only against specific indices: this rolls back a simplification that Van and Carlo put in when they were troubleshooting. It means that when a request for a filtered suggestion is sent in, we send the modified query to the index it was originally sent to, rather than assuming they can all go to `logs-app*`. this is better for both performance and generalization
-

## Security Considerations

Properly filters users' queries so we can safely re-enable search suggestions