### PR TITLE
Add test script to run tests in ci task later

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ src/logsearch-config/vendor/logstash*
 #Concourse ignores
 ci/secret.yml
 ci/pipeline-merged.yml
+
+#vscode artifacts
+.vscode

--- a/packages/kibana-auth-plugin/spec
+++ b/packages/kibana-auth-plugin/spec
@@ -3,3 +3,8 @@ name: kibana-auth-plugin
 
 files:
   - kibana-cf_authentication/**/*
+
+excluded_files:
+  - kibana-cf_authentication/**/*.test.js
+  - kibana-cf_authentication/README.md
+  - kibana-cf_authentication/jest.config.js

--- a/src/kibana-cf_authentication/README.md
+++ b/src/kibana-cf_authentication/README.md
@@ -1,0 +1,19 @@
+# kibana-cf_authentication
+
+This plugin performs authentication and authorization for kibana.
+Details on its working are spelled out in comments in [server/index.js](server/index.js)
+
+The high-level is:
+
+- users who are not authenticated are sent to authenticate
+- users who are authenticated are considered admins if they are a member of a specific, configurable cf org
+- users who are not admins have filters injected (server-side) to limit search results to their orgs/spaces
+  (_n.b. this is applied on an endpoint-by-endpoint basis_)
+- responses from the /api/capabilities endpoint are modified to hide irrelevant options from admins and users
+- responses from the /api/capabilities endpoint are further modified to hide administrative options from users
+
+## Developing
+
+Tests are set up to use [jest](https://jestjs.io). Jest is not included package.json / package-lock.json
+to keep node_modules (which is vendored into the bosh release) slimmer and more straightforward. It's recommended
+that you install jest outside of this repository.

--- a/src/kibana-cf_authentication/jest.config.js
+++ b/src/kibana-cf_authentication/jest.config.js
@@ -1,0 +1,194 @@
+/*
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/en/configuration.html
+ */
+
+module.exports = {
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after `n` failures
+  // bail: 0,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/private/var/folders/qx/962k74pd6y30wp33nrl7jm080000gp/T/jest_dy",
+
+  // Automatically clear mock calls and instances between every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  // collectCoverage: false,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: undefined,
+
+  // The directory where Jest should output its coverage files
+  // coverageDirectory: undefined,
+
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // Indicates which provider should be used to instrument code for coverage
+  // coverageProvider: "babel",
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: undefined,
+
+  // A path to a custom dependency extractor
+  // dependencyExtractor: undefined,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // Force coverage collection from ignored files using an array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: undefined,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: undefined,
+
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
+
+  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // maxWorkers: "50%",
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "json",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "node"
+  // ],
+
+  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+  // moduleNameMapper: {},
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "failure-change",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: undefined,
+
+  // Run tests from one or more projects
+  // projects: undefined,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state between every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: undefined,
+
+  // Automatically restore mock state between every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: undefined,
+
+  // A list of paths to directories that Jest should use to search for files in
+  // roots: [
+  //   "<rootDir>"
+  // ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: [],
+
+  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  // setupFilesAfterEnv: [],
+
+  // The number of seconds after which a test is considered as slow and reported as such in the results.
+  // slowTestThreshold: 5,
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  testEnvironment: "node",
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  // testMatch: [
+  //   "**/__tests__/**/*.[jt]s?(x)",
+  //   "**/?(*.)+(spec|test).[tj]s?(x)"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  // testPathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // The regexp pattern or array of patterns that Jest uses to detect test files
+  // testRegex: [],
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: undefined,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jasmine2",
+
+  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+  // testURL: "http://localhost",
+
+  // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
+  // timers: "real",
+
+  // A map from regular expressions to paths to transformers
+  // transform: undefined,
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/",
+  //   "\\.pnp\\.[^\\/]+$"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: undefined,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+};

--- a/src/kibana-cf_authentication/package.json
+++ b/src/kibana-cf_authentication/package.json
@@ -33,5 +33,8 @@
     "grunt-clean": "^0.4.0",
     "grunt-less": "^0.1.7"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "npx jest"
+  }
 }

--- a/src/kibana-cf_authentication/server/ensureKeys.test.js
+++ b/src/kibana-cf_authentication/server/ensureKeys.test.js
@@ -1,0 +1,20 @@
+const {ensureKeys} = require('./helpers')
+
+
+test('returns same when keys present', () => {
+    let obj =  {'foo': {'bar':{'baz':{}}}}
+    expect(ensureKeys(obj, ['foo','bar','baz'])).toBe(obj.foo.bar.baz);
+    expect(obj).toEqual({'foo': {'bar':{'baz':{}}}});
+});
+
+test('adds keys when not present', () => {
+    let obj = {'foo': {}};
+    expect(ensureKeys(obj, ['foo','bar','baz'])).toBe(obj.foo.bar.baz);
+    expect(obj).toEqual({'foo': {'bar':{'baz':{}}}});
+});
+
+test('does not mess with siblings', () => {
+    let obj = {'foo': {'quux': {}}};
+    expect(ensureKeys(obj, ['foo','bar','baz'])).toBe(obj.foo.bar.baz);
+    expect(obj).toEqual({'foo': {'quux': {}, 'bar':{'baz':{}}}});
+})

--- a/src/kibana-cf_authentication/server/helpers.js
+++ b/src/kibana-cf_authentication/server/helpers.js
@@ -64,6 +64,7 @@ const filterQuery = (payload, cached) => {
 }
 
 module.exports = {
+  ensureKeys,
   filterQuery,
   filterInternalQuery,
   filterSuggestionQuery


### PR DESCRIPTION
## Changes Proposed

- Add the `script` tag with `test` command to `package.json` to run tests in a future CI task without needing to install dev dependencies
- CI task will be able to run tests with `$ npm test` command

## Security Considerations
None
