### PR TITLE
Revert "add bad test to test ci"

### DIFF
--- a/src/kibana-cf_authentication/server/ensureKeys.test.js
+++ b/src/kibana-cf_authentication/server/ensureKeys.test.js
@@ -18,7 +18,3 @@ test('does not mess with siblings', () => {
     expect(ensureKeys(obj, ['foo','bar','baz'])).toBe(obj.foo.bar.baz);
     expect(obj).toEqual({'foo': {'quux': {}, 'bar':{'baz':{}}}});
 })
-
-test('failed tests break ci', () => {
-    expect(false).toEqual(true);
-})


### PR DESCRIPTION
Reverts cloud-gov/logsearch-for-cloudfoundry#71

All done testing

# Security Considerations
None
