### PR TITLE
return the response rather than the text

### DIFF
--- a/src/kibana-cf_authentication/server/routes.js
+++ b/src/kibana-cf_authentication/server/routes.js
@@ -430,9 +430,7 @@ module.exports = (server, config, cache) => {
         },
         validate: { payload: null },
         handler: async (request, h) => {
-          let response = h.response()
-          response = response.code(401)
-          return 'forbidden'
+          return h.response("forbidden").code(401)
         }
       }
     }


### PR DESCRIPTION


## Changes Proposed

- return the response rather than the text; I don't know why the rest of the routes aren't doing this, but we need
to return the response object rather than the response body

## Security Considerations

None