### PR TITLE
add ids to grok and json filters

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-app.conf
@@ -20,34 +20,35 @@ if [@type] == "LogMessage" and [@source][type] =~ /APP(|\/.*)$/ {
     if [@message] =~ /^\s*{".*}\s*$/ { # if it looks like JSON
 
         json {
-          source => "@message"
-          target => "app"
+            source => "@message"
+            target => "app"
+            id => "cloudfoundry/app-app/json"
         }
 
         if !("_jsonparsefailure" in [tags]) {
 
             mutate {
-              rename => { "[app][message]" => "@message" } # @message
+                rename => { "[app][message]" => "@message" } # @message
             }
             # concat message and exception
             if [app][exception] {
-              mutate {
-                ## NOTE: keep line break and new line spacing (new line is inserted in logstash in such a way)
-                replace => { "@message" => "%{@message}
+                mutate {
+                    ## NOTE: keep line break and new line spacing (new line is inserted in logstash in such a way)
+                    replace => { "@message" => "%{@message}
 %{[app][exception]}" }
-                remove_field => [ "[app][exception]" ]
+                    remove_field => [ "[app][exception]" ]
               }
             }
 
             mutate {
-              rename => { "[app][level]" => "@level" } # @level
+                rename => { "[app][level]" => "@level" } # @level
             }
 
         } else {
 
             mutate {
-              add_tag => [ "unknown_msg_format" ]
-              remove_tag => ["_jsonparsefailure"]
+                add_tag => [ "unknown_msg_format" ]
+                remove_tag => ["_jsonparsefailure"]
             }
         }
 
@@ -56,23 +57,25 @@ if [@type] == "LogMessage" and [@source][type] =~ /APP(|\/.*)$/ {
 
         # Tomcat specific parsing (in accordance with https://github.com/cloudfoundry/java-buildpack-support/blob/master/tomcat-logging-support/src/main/java/com/gopivotal/cloudfoundry/tomcat/logging/CloudFoundryFormatter.java)
         grok {
-          match => [ "@message", "(?<app_logger>\[CONTAINER\]%{SPACE}%{NOTSPACE})%{SPACE}%{LOGLEVEL:@level}%{SPACE}%{GREEDYDATA:@message}" ]
-          overwrite => [ "@message", "@level" ]
-          tag_on_failure => [ "unknown_msg_format" ]
+            match => [ "@message", "(?<app_logger>\[CONTAINER\]%{SPACE}%{NOTSPACE})%{SPACE}%{LOGLEVEL:@level}%{SPACE}%{GREEDYDATA:@message}" ]
+            overwrite => [ "@message", "@level" ]
+            tag_on_failure => [ "unknown_msg_format" ]
+            id => "cloudfoundry/app-app/tomcat/grok"
         }
         mutate {
-          rename => { "app_logger" => "[app][logger]" }
+            rename => { "app_logger" => "[app][logger]" }
         }
 
     } else {
 
         ## ---- Format 3: Logback status logs
         grok {
-          match => [ "@message", "%{TIME} \|\-%{LOGLEVEL:@level} in %{NOTSPACE:[app][logger]} - %{GREEDYDATA:@message}" ]
-          overwrite => [ "@message", "@level" ]
+            match => [ "@message", "%{TIME} \|\-%{LOGLEVEL:@level} in %{NOTSPACE:[app][logger]} - %{GREEDYDATA:@message}" ]
+            overwrite => [ "@message", "@level" ]
 
-          ## ---- Unknown Format: if no formats succeeded set with 'unknown_msg_format' tag
-          tag_on_failure => [ "unknown_msg_format" ]
+            ## ---- Unknown Format: if no formats succeeded set with 'unknown_msg_format' tag
+            tag_on_failure => [ "unknown_msg_format" ]
+            id => "cloudfoundry/app-app/logback/grok"
         }
     }
 

--- a/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
@@ -22,6 +22,7 @@ if ( [@type] == "LogMessage" and [@source][type] == "RTR" ) {
         "^%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}"
         ]
       ]
+      id => "cloudfoundry/app-rtr/grok"
 
       tag_on_failure => [ "fail/cloudfoundry/app-rtr/grok" ]
     }

--- a/src/logsearch-config/src/logstash-filters/snippets/app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app.conf
@@ -14,6 +14,7 @@ if [@index_type] == "app" {
     json {
       source => "@message"
       target => "parsed_json_field"
+      id => "cloudfoundry/app/json"
     }
 
     if "_jsonparsefailure" in [tags] {

--- a/src/logsearch-config/src/logstash-filters/snippets/platform-cloud_controller_ng.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform-cloud_controller_ng.conf
@@ -11,6 +11,7 @@ if [@source][component] == "cloud_controller_ng" {
   grok {
     match => { "@message" => "%{URIHOST:Request_Host} %{NOTSPACE} \[%{MONTHDAY}/%{MONTH}/%{YEAR}:%{TIME} %{ISO8601_TIMEZONE}\] \"%{WORD:Request_Method} %{URIPATHPARAM:Request_URL} %{SYSLOGPROG:Request_Protocol}\" %{NUMBER:Status_Code:int} %{NUMBER:Bytes_Received:int} \"%{NOTSPACE:Referer}\" \"%{DATA:User_Agent}\" %{URIHOST:Backend_Address} vcap_request_id:%{DATA:X_Vcap_Request_ID} response_time:%{NUMBER:Response_Time}" }
     tag_on_failure => "fail/cloudfoundry/platform-cloud_controller_ng/grok"
+    id => "cloudfoundry/platform-cloud_controller_ng/grok"
   }
 
 }

--- a/src/logsearch-config/src/logstash-filters/snippets/platform-gorouter.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform-gorouter.conf
@@ -3,12 +3,13 @@
 ##------------------------------------+
 
 if [@index_type] == "platform" and [@source][component] == "gorouter" {
-            if [@message] =~ "\A\{.+\}\z" {
-                  json {
-                      source => "@message"
-                      add_tag => [ "router/syslog" ]
-                      tag_on_failure => [ "router/parsing_failed" ]
-                  }
+    if [@message] =~ "\A\{.+\}\z" {
+        json {
+            source => "@message"
+            add_tag => [ "router/syslog" ]
+            tag_on_failure => [ "router/parsing_failed" ]
+            id => "router/accesslog/json"
+        }
     } else {
         grok {
             match => [ "@message", [
@@ -24,6 +25,7 @@ if [@index_type] == "platform" and [@source][component] == "gorouter" {
                 "^%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}"
                 ]
             ]
+            id => "router/accesslog/grok"
             overwrite => [ "@message" ]
             add_tag => "router/accesslog"
             tag_on_failure => "router/parsing_failed"

--- a/src/logsearch-config/src/logstash-filters/snippets/platform-haproxy.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform-haproxy.conf
@@ -16,6 +16,7 @@ if [@source][component] == "haproxy" {
     grok {
       match => [ "@message", "%{IP:[haproxy][client_ip]}:%{INT:[haproxy][client_port]:int} \[%{DATA:[haproxy][accept_date]}\] %{NOTSPACE:[haproxy][frontend_name]} %{NOTSPACE:[haproxy][backend_name]}/%{NOTSPACE:[haproxy][server_name]} %{INT:[haproxy][time_request]:int}/%{INT:[haproxy][time_queue]:int}/%{INT:[haproxy][time_backend_connect]:int}/%{INT:[haproxy][time_backend_response]:int}/%{INT:[haproxy][time_duration]:int} %{INT:[haproxy][http_status_code]:int} %{NOTSPACE:[haproxy][bytes_read]:int} %{DATA:[haproxy][captured_request_cookie]} %{DATA:[haproxy][captured_response_cookie]} %{NOTSPACE:[haproxy][termination_state]} %{INT:[haproxy][actconn]:int}/%{INT:[haproxy][feconn]:int}/%{INT:[haproxy][beconn]:int}/%{INT:[haproxy][srvconn]:int}/%{NOTSPACE:[haproxy][retries]:int} %{INT:[haproxy][srv_queue]:int}/%{INT:[haproxy][backend_queue]:int} (\{%{DATA:[haproxy][captured_request_headers]}\})?( )?(\{%{DATA:[haproxy][captured_response_headers]}\})?( )?\"(?<message>(?<haproxy_http_request>(<BADREQ>|((%{WORD:[haproxy][http_request_verb]})?( %{GREEDYDATA})?))))\"" ]
       match => [ "@message", "%{IP:[haproxy][client_ip]}:%{INT:[haproxy][client_port]:int} \[%{DATA:[haproxy][accept_date]}\] %{NOTSPACE:[haproxy][frontend_name]}/%{NOTSPACE:[haproxy][bind_name]}:%{SPACE}%{GREEDYDATA:message}" ]
+      id => "cloudfoundry/platform-haproxy/grok"
       tag_on_failure => "fail/cloudfoundry/platform-haproxy/grok"
     }
 

--- a/src/logsearch-config/src/logstash-filters/snippets/platform-uaa.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform-uaa.conf
@@ -14,6 +14,7 @@ if [@source][component] == "vcap.uaa" {
     grok {
       match => { "@message" => "\[%{TIMESTAMP_ISO8601:[uaa][timestamp]}\]%{SPACE}uaa%{SPACE}-%{SPACE}%{NUMBER:[uaa][pid]:int}%{SPACE}\[%{DATA:[uaa][thread]}\]%{SPACE}....%{SPACE}%{LOGLEVEL:@level}%{SPACE}---%{SPACE}%{DATA:[uaa][log_category]}:%{SPACE}%{GREEDYDATA:@message}"}
       overwrite => ["@message", "@level"] # @message, @level
+      id => "cloudfoundry/platform-uaa/grok"
       tag_on_failure => "fail/cloudfoundry/platform-uaa/grok"
     }
 
@@ -29,6 +30,7 @@ if [@source][component] == "vcap.uaa" {
 
         grok {
           match => { "@message" => "(?<uaa_audit_message>(%{WORD:[uaa][audit][type]}%{SPACE}\('%{DATA:[uaa][audit][data]}'\))):%{SPACE}principal=%{DATA:[uaa][audit][principal]},%{SPACE}origin=\[%{DATA:[uaa][audit][origin]}\],%{SPACE}identityZoneId=\[%{DATA:[uaa][audit][identity_zone_id]}\]"}
+          id => "cloudfoundry/platform-uaa/audit/grok"
           tag_on_failure => "fail/cloudfoundry/platform-uaa/audit/grok"
         }
 
@@ -48,6 +50,7 @@ if [@source][component] == "vcap.uaa" {
             if [uaa][audit][origin] =~ /remoteAddress=/ {
                 grok {
                   match => { "[uaa][audit][origin]" => "remoteAddress=%{IP:[uaa][audit][remote_address]}" }
+                  id => "cloudfoundry/platform-uaa/audit/origin/grok"
                 }
             }
             if [uaa][audit][remote_address] {

--- a/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
@@ -18,33 +18,34 @@ if [@source][component] != "vcap.uaa" and [@source][component] =~ /vcap\..*/ {
 
         # parse JSON message
         json {
-          source => "@message"
-          target => "parsed_json_field"
-          remove_field => [ "@message" ]
-          add_field => { "parsed_json_field_name" => "%{[@source][component]}"}
+            source => "@message"
+            target => "parsed_json_field"
+            remove_field => [ "@message" ]
+            add_field => { "parsed_json_field_name" => "%{[@source][component]}"}
+            id => "cloudfoundry/platform-vcap/json"
         }
 
         if "_jsonparsefailure" in [tags] {
             # Amend the failure tag to match our fail/${addon}/${filter}/${detail} standard
             mutate {
-              add_tag => ["fail/cloudfoundry/platform-vcap/json"]
-              remove_tag => ["_jsonparsefailure"]
+                add_tag => ["fail/cloudfoundry/platform-vcap/json"]
+                remove_tag => ["_jsonparsefailure"]
             }
 
         } else {
 
             mutate {
-              rename => { "[parsed_json_field][message]" => "@message" } # @message
+                rename => { "[parsed_json_field][message]" => "@message" } # @message
             }
 
             # @level
             translate {
-              field => "[parsed_json_field][log_level]"
-              dictionary => [ "0", "DEBUG", "1", "INFO", "2", "ERROR", "3", "FATAL" ]
-              destination => "@level"
-              override => true
-              fallback => "%{[parsed_json_field][log_level]}"
-              remove_field => "[parsed_json_field][log_level]"
+                field => "[parsed_json_field][log_level]"
+                dictionary => [ "0", "DEBUG", "1", "INFO", "2", "ERROR", "3", "FATAL" ]
+                destination => "@level"
+                override => true
+                fallback => "%{[parsed_json_field][log_level]}"
+                remove_field => "[parsed_json_field][log_level]"
             }
         }
 

--- a/src/logsearch-config/src/logstash-filters/snippets/platform.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform.conf
@@ -34,6 +34,7 @@ if [@index_type] == "platform" {
             match => [ "@message", "\[bosh instance=%{NOTSPACE:[@source][deployment]}/%{NOTSPACE:[@source][job]}/%{NOTSPACE:[@source][job_index]}\]%{SPACE}%{GREEDYDATA:@message}" ]
 
             overwrite => [ "@message" ] # @message
+            id => "cloudfoundry/platform/grok"
             tag_on_failure => "fail/cloudfoundry/platform/grok"
         }
 


### PR DESCRIPTION
## Changes Proposed

- add ids to grok and json filters. When we don't set IDs, logsearch sets them dynamically, but there's no way I've found to trace them back. Adding ids to these filters should make it easier to debug performance issues and track filter usage

I also tidied up a bunch of whitespace in the process, so I'd recommend viewing this PR with whitespace changes ignored.

## Security Considerations

None