### PR TITLE
Lock down CSV generation endpoint

### DIFF
--- a/src/kibana-cf_authentication/server/helpers.js
+++ b/src/kibana-cf_authentication/server/helpers.js
@@ -16,6 +16,22 @@ const ensureKeys = (value, keys) => {
   return value
 }
 
+const filterCSVReportingQuery = (payload, cached) => {
+  // query for /api/reporting/generate/csv/ endpoints after kibana 7.7
+  let bool = ensureKeys(payload, ['jobsParams', 'searchRequest', 'body', 'query', 'bool'])
+
+  bool.must = bool.must || []
+  // Note: the `must` clause may be an array or an object
+  if (isObject(bool.must)) {
+    bool.must = [bool.must]
+  }
+  bool.must.push(
+    { 'terms': { '@cf.space_id': cached.account.spaceIds } },
+    { 'terms': { '@cf.org_id': cached.account.orgIds } }
+  )
+  return payload
+}
+
 const filterSuggestionQuery = (payload, cached) => {
   // query for /api/kibana/suggestions/values/<index name> endpoints after kibana 7.7
   let boolFilter = payload.boolFilter || []
@@ -93,6 +109,7 @@ const pathAllowed = (requestPath, server=console) => {
     /^\/?oauth\/authorize/,
     /^\/?plugins\/authenication/,
     /^\/?node_modules/,
+    /^\/?api\/reporting\/generate\/csv/,
   ]
   const denylist = [
     /^\/?app\/indexPatterns/,

--- a/src/kibana-cf_authentication/server/index.js
+++ b/src/kibana-cf_authentication/server/index.js
@@ -174,6 +174,8 @@ module.exports = (kibana) => {
           } else if (/elasticsearch\/([^\/]+)\/_search/.test(request.path)) {
             const match = /elasticsearch\/([^\/]+)\/_search/.exec(request.path)
             request.setUrl('/' + match[1] + '/_filtered_search')
+          } else if (/api\/reporting\/generate\/csv/.test(request.path) && !request.auth.artifacts) {
+            request.setUrl('/_filtered_generated_csv')
           } else if (!pathAllowed(request.path, server)) {
             request.setUrl('/401')
           }


### PR DESCRIPTION
This changeset adds filters for the org and space of a user, just like we had done for the filter suggestions and main search results previously.  This prevents CSVs from being generated that include all logs, instead of just the logs specific to a customer.

## Changes Proposed
- Add specific CSV endpoint to the `allowlist`
- Add a filter method for the CSV report endpoint
- Add a route handler for the CSV report endpoint

## Security Considerations
- Locks down CSV generation to only include log output that is visible to a given customer