### PR TITLE
Allow the CSV endpoint to work

### DIFF
--- a/src/kibana-cf_authentication/server/helpers.js
+++ b/src/kibana-cf_authentication/server/helpers.js
@@ -120,7 +120,7 @@ const pathAllowed = (requestPath, server=console) => {
     /^\/?app\/management\/stack\/license_management/,
     /^\/?app\/dev_tools/,
     /^\/?api\/painless_lab/,
-    /^\/?api\/reporting/
+    // /^\/?api\/reporting/
   ]
 
   for (const denied of denylist) {


### PR DESCRIPTION
We will need to adjust the denylist after to account for the PDF report endpoint.

## Changes Proposed
- Updates the `denylist` to remove the reporting endpoint for now

## Security Considerations
- The PDF endpoint (and any other reporting endpoints) will still need to be accounted for once we finish our CSV testing
