### PR TITLE
Attempt to fix CSV Report Generation

### DIFF
--- a/src/kibana-cf_authentication/package.json
+++ b/src/kibana-cf_authentication/package.json
@@ -25,6 +25,7 @@
     "randomstring": "^1.1.5",
     "redis": "^2.4.2",
     "request": "^2.65.0",
+    "rison-node": "^2.1.1",
     "topo": "^1.1.0",
     "uuid": "^2.0.1",
     "wreck": "^14.2.0"


### PR DESCRIPTION
This changeset is an attempt to fix the CSV report generation in Kibana.  It adds support for Rison string processing, which is required to process the payload Kibana creates for generating a CSV (see https://www.elastic.co/guide/en/kibana/7.x/reporting-integration.html for details).

## Changes Proposed
- Adds the `rison-node` package for Rison string processing
- Updates the `jobsParams` payload processing to account for the Rison string

## Security Considerations
- Attempts to fix the log leakage we experienced with the CSV report in Kibana