### PR TITLE
Fix CSV URL and request payload handling

### DIFF
--- a/src/kibana-cf_authentication/server/helpers.js
+++ b/src/kibana-cf_authentication/server/helpers.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const rison = require('rison-node')
 
 const isObject = (value) => {
   return value instanceof Object && !(value instanceof Array)
@@ -19,11 +18,7 @@ const ensureKeys = (value, keys) => {
 
 const filterCSVReportingQuery = (payload, cached) => {
   // query for /api/reporting/generate/csv/ endpoints after kibana 7.7
-  // Requires Rison processing support to account for the jobsParams payload
-  // See https://www.elastic.co/guide/en/kibana/7.x/reporting-integration.html
-  let jobParams = ensureKeys(payload, ['jobParams'])
-  let decodedJobParams = rison.decode(jobParams)
-  let bool = ensureKeys(decodedJobParams, ['searchRequest', 'body', 'query', 'bool'])
+  let bool = ensureKeys(payload, ['searchRequest', 'body', 'query', 'bool'])
 
   bool.must = bool.must || []
   // Note: the `must` clause may be an array or an object
@@ -35,7 +30,6 @@ const filterCSVReportingQuery = (payload, cached) => {
     { 'terms': { '@cf.org_id': cached.account.orgIds } }
   )
 
-  payload.jobParams = rison.encode(decodedJobParams)
   return payload
 }
 

--- a/src/kibana-cf_authentication/server/routes.js
+++ b/src/kibana-cf_authentication/server/routes.js
@@ -1,3 +1,4 @@
+const rison = require('rison-node')
 const { filterQuery, filterInternalQuery, filterSuggestionQuery } = require('./helpers')
 
 module.exports = (server, config, cache) => {
@@ -309,7 +310,7 @@ module.exports = (server, config, cache) => {
         handler: async (request, h) => {
           const options = {
             method: 'POST',
-            url: '/api/reporting/generate/csv',
+            url: '/api/reporting/generate/csv?jobParams=' + request.payload,
             artifacts: true
           };
           let cached
@@ -317,8 +318,12 @@ module.exports = (server, config, cache) => {
             cached = await cache.get(request.auth.credentials.session_id)
 
             if (cached.account.orgs.indexOf(config.get('authentication.cf_system_org')) === -1 && !(config.get('authentication.skip_authorization'))) {
+              // Requires Rison processing support to account for the jobParams payload
+              // See https://www.elastic.co/guide/en/kibana/7.x/reporting-integration.html
               let payload = JSON.parse(request.payload.toString() || '{}')
-              payload = filterCSVReportingQuery(payload, cached)
+              let decodedJobParams = rison.decode(payload.jobParams)
+              decodedJobParams = filterCSVReportingQuery(decodedJobParams, cached)
+              payload.jobParams = rison.encode(decodedJobParams)
               options.payload = new Buffer(JSON.stringify(payload))
             } else {
               options.payload = request.payload

--- a/src/kibana-cf_authentication/server/routes.js
+++ b/src/kibana-cf_authentication/server/routes.js
@@ -322,8 +322,8 @@ module.exports = (server, config, cache) => {
               // See https://www.elastic.co/guide/en/kibana/7.x/reporting-integration.html
               let payload = JSON.parse(request.payload.toString() || '{}')
               let decodedJobParams = rison.decode(payload.jobParams)
-              decodedJobParams = filterCSVReportingQuery(decodedJobParams, cached)
-              payload.jobParams = rison.encode(decodedJobParams)
+              let updatedJobParams = filterCSVReportingQuery(decodedJobParams, cached)
+              payload.jobParams = rison.encode(updatedJobParams)
               options.payload = new Buffer(JSON.stringify(payload))
             } else {
               options.payload = request.payload


### PR DESCRIPTION
Previously, we thought that the payload itself was the value of the `jobParam` query parameter, but it appears that the payload includes this as well.  We need to decode the Rison value before modifying the underlying `bool` filter and then encode it again when injecting them into the request payload on the server itself.  This changeset attempts to fix the order of things to make this work.

## Changes Proposed
- Shifts the Rison encoding/decoding to the URL handler itself
- Hopefully adjusts the request payload properly

## Security Considerations
- None; still attempting to make the CSV report work with the correct filters