### PR TITLE
Minor fixes to try CSV report generation again

### DIFF
--- a/src/kibana-cf_authentication/server/helpers.js
+++ b/src/kibana-cf_authentication/server/helpers.js
@@ -36,6 +36,7 @@ const filterCSVReportingQuery = (payload, cached) => {
   )
 
   jobParams = rison.encode(decodedJobParams)
+  payload.jobParams = jobParams
 
   return payload
 }

--- a/src/kibana-cf_authentication/server/routes.js
+++ b/src/kibana-cf_authentication/server/routes.js
@@ -319,7 +319,7 @@ module.exports = (server, config, cache) => {
 
             if (cached.account.orgs.indexOf(config.get('authentication.cf_system_org')) === -1 && !(config.get('authentication.skip_authorization'))) {
               let payload = JSON.parse(request.payload.toString() || '{}')
-              payload = filterCSVReportingQuery(decodedJobParams, cached)
+              payload = filterCSVReportingQuery(payload, cached)
               options.payload = new Buffer(JSON.stringify(payload))
             } else {
               options.payload = request.payload


### PR DESCRIPTION
This changeset introduces a couple of minor fixes to attempt making the CSV report generation work.

## Changes Proposed
- Fixes a variable reference
- Makes sure the main `jobParams` request property is reset with the updated values

## Security Considerations
- Sill trying to ensure the CSV report generation accounts for user authorization (proper space and org access)