### PR TITLE
Make sure console is available in the filterCSVReportingQuery method

### DIFF
--- a/src/kibana-cf_authentication/server/helpers.js
+++ b/src/kibana-cf_authentication/server/helpers.js
@@ -17,7 +17,7 @@ const ensureKeys = (value, keys) => {
   return value
 }
 
-const filterCSVReportingQuery = (payload, cached) => {
+const filterCSVReportingQuery = (payload, cached, server=console) => {
   // query for /api/reporting/generate/csv/ endpoints after kibana 7.7
   // Requires Rison processing support to account for the jobParams payload
   // See https://www.elastic.co/guide/en/kibana/7.x/reporting-integration.html


### PR DESCRIPTION
## Changes Proposed
- Explicitly pass `console` into the method to make sure it is within scope

## Security Considerations
- Logging statements need to be removed when debugging is done