### PR TITLE
add mapping for "app" field as flattened type 

### DIFF
--- a/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
@@ -28,6 +28,9 @@ keyword_default = { "type": "keyword", "index": true }.to_json
             "space_id":     <%= keyword_default %>
           }
         },
+        "app": {
+          "type": "flattened",
+        },
         "logmessage": {
           "type": "object",
           "dynamic": true,
@@ -124,7 +127,7 @@ keyword_default = { "type": "keyword", "index": true }.to_json
             "source":  <%= keyword_default %>,
             "code": { "type": "long" }
           }
-        },      
+        },
         "httpstartstop": {
           "type": "object",
           "dynamic": true,

--- a/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
@@ -29,7 +29,7 @@ keyword_default = { "type": "keyword", "index": true }.to_json
           }
         },
         "app": {
-          "type": "flattened",
+          "type": "flattened"
         },
         "logmessage": {
           "type": "object",


### PR DESCRIPTION
## Changes Proposed

Currently, [when Logstash receives an input log that is JSON, it parses the JSON properties into a field called `app`](https://github.com/cloud-gov/logsearch-for-cloudfoundry/blob/develop/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-app.conf#L24).

While this behavior is nice in that it allows logs to be searched by the custom properties from the JSON log (based on the detected field type for each JSON property), it can lead to a "mapping explosion" where fields dynamically generated from JSON logs hit the available field limit as discussed here: https://discuss.elastic.co/t/approaches-to-deal-with-limit-of-total-fields-1000-in-index-has-been-exceeded/241039. And once the total field limit for an index has been hit, no other logs with custom fields can be indexed, which creates a "tragedy of the commons" issue when logs for multiple customer orgs are co-located within the same index.

One of the proposed solutions to the "mapping explosion" problem is to use a [`flattened` type for handling dynamic fields from JSON logs](https://www.elastic.co/guide/en/elasticsearch/reference/current/flattened.html). When you use a `flattened` field type, the entire object for a custom JSON log is indexed and still searchable, but only using basic search functionality. 

So for a log like:

```
{"custom":{"foo":"bar"}}
```

You could search for the document like so:

```
custom.foo: "bar"
```

The only downside of `flattened` fields is that they can only be queried using basic search functionality, but that should be sufficient for letting users query their documents in Kibana. The enormous upside is that a `flattened` field can contain a complex data-structure for searching, but only takes up **1 field in your index mappings, not 1 field per custom property in the JSON logs**.

I have tested this approach manually in the dev environment and confirms that it works as described above.

So this PR adds a default mapping for the `app` field to be a `flattened` type, since that is the field where Logstash is placing the contents of custom JSON logs.

## Security Considerations

There are no changes to security configuration for Elasticsearch here, just changing the destination field type for custom JSON logs.
