### PR TITLE
remove mapping of "app" field as "flattened" type

### DIFF
--- a/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
@@ -28,9 +28,6 @@ keyword_default = { "type": "keyword", "index": true }.to_json
             "space_id":     <%= keyword_default %>
           }
         },
-        "app": {
-          "type": "flattened"
-        },
         "logmessage": {
           "type": "object",
           "dynamic": true,


### PR DESCRIPTION
## Changes Proposed

Follow-up to #115 

- remove mapping of "app" field as "flattened" type. It turns out the `flattened` field type is not supported by default in Elasticsearch 7.9, but is only offered as part of the `x-pack`: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/flattened.html

## Security Considerations

None
