### PR TITLE
Re-add flattened mapping for app type

### DIFF
--- a/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
@@ -28,6 +28,9 @@ keyword_default = { "type": "keyword", "index": true }.to_json
             "space_id":     <%= keyword_default %>
           }
         },
+        "app": {
+          "type": "flattened"
+        },
         "logmessage": {
           "type": "object",
           "dynamic": true,


### PR DESCRIPTION
## Changes Proposed

- This was rolled back in d7fc138 due to a failure in deployment. I want to reproduce the failure since the logs have been cleaned up.
- The expected behavior is that this deploys successfully. It's a component template referenced by index templates, so there should be no conflict with existing indexes. 
- Related to https://github.com/cloud-gov/logsearch-boshrelease/issues/161

## Security Considerations

None.
