### PR TITLE
chore: downgrade some hapi modules to satisfy requirements

### DIFF
--- a/src/kibana-cf_authentication/package-lock.json
+++ b/src/kibana-cf_authentication/package-lock.json
@@ -546,41 +546,14 @@
       "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="
     },
     "@hapi/catbox": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
-      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.0.0.tgz",
+      "integrity": "sha512-rEE2wAHWecdViqkdXUpt1Fv2uvcvSrxLri7jrGE3Wpf6fD5lNErORaBzjFnzcTxYu/e6ADCKrONojbRzUZpivA==",
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x",
-        "@hapi/podium": "4.x.x",
-        "@hapi/validate": "1.x.x"
-      },
-      "dependencies": {
-        "@hapi/boom": {
-          "version": "9.1.4",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
-          "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
-          "requires": {
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "@hapi/topo": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-          "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-          "requires": {
-            "@hapi/hoek": "^9.0.0"
-          }
-        },
-        "@hapi/validate": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
-          "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
-          "requires": {
-            "@hapi/hoek": "^9.0.0",
-            "@hapi/topo": "^5.0.0"
-          }
-        }
+        "@hapi/joi": "17.x.x",
+        "@hapi/podium": "4.x.x"
       }
     },
     "@hapi/cookie": {
@@ -676,25 +649,6 @@
         "@hapi/hoek": "9.x.x",
         "@hapi/teamwork": "5.x.x",
         "@hapi/validate": "1.x.x"
-      },
-      "dependencies": {
-        "@hapi/topo": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-          "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-          "requires": {
-            "@hapi/hoek": "^9.0.0"
-          }
-        },
-        "@hapi/validate": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
-          "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
-          "requires": {
-            "@hapi/hoek": "^9.0.0",
-            "@hapi/topo": "^5.0.0"
-          }
-        }
       }
     },
     "@hapi/teamwork": {

--- a/src/kibana-cf_authentication/package.json
+++ b/src/kibana-cf_authentication/package.json
@@ -19,7 +19,7 @@
     "@hapi/boom": "^9.1.4",
     "@hapi/bounce": "^2.0.0",
     "@hapi/bourne": "^3.0.0",
-    "@hapi/catbox": "^11.1.1",
+    "@hapi/catbox": "11.0.0",
     "got": "^11.8.6",
     "@hapi/cookie": "^11.0.2",
     "@hapi/hoek": "^9.0.3",


### PR DESCRIPTION
Downgrading `hapi` packages to ones that work with node 10

note: hapi/teamwork@5.0.0 seems not to work with our version of node, but I think we also can't pin it to <5.0, because hapi/catbox@11.0.0 requires hapi/teamwork@^5.1.1. I think that means this won't work, but I'm throwing it at the wall to see if it sticks. If it doesn't work, we will need to figure something else out.

## Changes Proposed

- downgrade some hapi modules to satisfy requirements


## Security Considerations

None