### PR TITLE
Change parsing for JSON logs

### DIFF
--- a/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
@@ -28,6 +28,9 @@ keyword_default = { "type": "keyword", "index": true }.to_json
             "space_id":     <%= keyword_default %>
           }
         },
+        "custom": {
+          "type": "flattened"
+        },
         "logmessage": {
           "type": "object",
           "dynamic": true,

--- a/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-app.conf
@@ -21,27 +21,27 @@ if [@type] == "LogMessage" and [@source][type] =~ /APP(|\/.*)$/ {
 
         json {
             source => "@message"
-            target => "app"
+            target => "custom"
             id => "cloudfoundry/app-app/json"
         }
 
         if !("_jsonparsefailure" in [tags]) {
 
             mutate {
-                rename => { "[app][message]" => "@message" } # @message
+                rename => { "[custom][message]" => "@message" } # @message
             }
             # concat message and exception
-            if [app][exception] {
+            if [custom][exception] {
                 mutate {
                     ## NOTE: keep line break and new line spacing (new line is inserted in logstash in such a way)
                     replace => { "@message" => "%{@message}
-%{[app][exception]}" }
-                    remove_field => [ "[app][exception]" ]
+%{[custom][exception]}" }
+                    remove_field => [ "[custom][exception]" ]
               }
             }
 
             mutate {
-                rename => { "[app][level]" => "@level" } # @level
+                rename => { "[custom][level]" => "@level" } # @level
             }
 
         } else {


### PR DESCRIPTION
## Changes Proposed

Currently, [when Logstash receives an input log that is JSON, it parses the JSON properties into a field called `app`](https://github.com/cloud-gov/logsearch-for-cloudfoundry/blob/develop/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-app.conf#L24).

While this behavior is nice in that it allows logs to be searched by the custom properties from the JSON log (based on the detected field type for each JSON property), it has the problem that the first log received for an index will determine the type of any fields parsed from the JSON log.

In our case where all customer logs are ingested into a shared index per day, this is problematic, since subsequent JSON logs may have different field types for keys that existed on JSON logs that have already been ingested. When this occurs, Elasticsearch will reject the incoming JSON log due to the mismatch in field types.

The proposed fix here is to use a [flattened type for handling dynamic fields from JSON logs](https://www.elastic.co/guide/en/elasticsearch/reference/current/flattened.html) on a new `custom` field. When you use a flattened field type, the entire object for a custom JSON log is indexed and still searchable, but only using basic search functionality.

So for a log like:

```
{"custom":{"foo":"bar"}}
```

You could search for the document like so:

```
custom.foo: "bar"
```

The only downside of `flattened` fields is that they can only be queried using basic search functionality, but that should be sufficient for letting users query their documents in Kibana. The enormous upside is that a `flattened` field can contain a complex data-structure for searching, but only takes up **1 field in your index mappings, not 1 field per custom property in the JSON logs**. Also, `flattened` fields will not be subject to the field type mismatch issues that are causing some customer logs to fail ingestion.

So this PR:

- Adds a default mapping for the `custom` field to be a `flattened` type
- Updates Logstash to parse incoming JSON into the `custom` field

## Security Considerations

There are no changes to security configuration for Elasticsearch here, just changing the destination field type for custom JSON logs.
