### PR TITLE
Revert "Change parsing for JSON logs (#143)"

### DIFF
--- a/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/component-index-mappings-app.json.erb
@@ -28,9 +28,6 @@ keyword_default = { "type": "keyword", "index": true }.to_json
             "space_id":     <%= keyword_default %>
           }
         },
-        "custom": {
-          "type": "flattened"
-        },
         "logmessage": {
           "type": "object",
           "dynamic": true,

--- a/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-app.conf
@@ -21,27 +21,27 @@ if [@type] == "LogMessage" and [@source][type] =~ /APP(|\/.*)$/ {
 
         json {
             source => "@message"
-            target => "custom"
+            target => "app"
             id => "cloudfoundry/app-app/json"
         }
 
         if !("_jsonparsefailure" in [tags]) {
 
             mutate {
-                rename => { "[custom][message]" => "@message" } # @message
+                rename => { "[app][message]" => "@message" } # @message
             }
             # concat message and exception
-            if [custom][exception] {
+            if [app][exception] {
                 mutate {
                     ## NOTE: keep line break and new line spacing (new line is inserted in logstash in such a way)
                     replace => { "@message" => "%{@message}
-%{[custom][exception]}" }
-                    remove_field => [ "[custom][exception]" ]
+%{[app][exception]}" }
+                    remove_field => [ "[app][exception]" ]
               }
             }
 
             mutate {
-                rename => { "[custom][level]" => "@level" } # @level
+                rename => { "[app][level]" => "@level" } # @level
             }
 
         } else {


### PR DESCRIPTION
This reverts commit 5d706d6b4e3e6b6ed2b6b85f48e2aec384965356.

## Changes Proposed

Reverts #143 because the changes aren't working in dev. They're having the same issues [described in this comment](https://github.com/cloud-gov/logsearch-boshrelease/issues/161#issuecomment-1971524540).

## Security Considerations

None, just changing how custom JSON logs are handled
